### PR TITLE
Register mention based on matcher char

### DIFF
--- a/examples/Components/Routes/Suggestions/index.vue
+++ b/examples/Components/Routes/Suggestions/index.vue
@@ -8,6 +8,10 @@
             <icon name="mention" />
             <span>Insert Mention</span>
           </button>
+           <button class="menubar__button" @click="commands.mention_hashtag({ id: 1, label: 'Dogs' })">
+            <span># &nbsp;</span>
+            <span>Insert Hashtag</span>
+          </button>
         </div>
       </editor-menu-bar>
       <editor-content class="editor__content" :editor="editor" />
@@ -138,6 +142,87 @@ export default {
               return fuse.search(query)
             },
           }),
+          new Mention({
+            matcher: {
+              char: '#',
+            },
+            tag: 'hashtag',
+            // a list of all suggested items
+            items: () => [
+              { id: 1, name: 'Dogs' },
+              { id: 2, name: 'Cats' },
+              { id: 3, name: 'Rabbits' },
+              { id: 4, name: 'Goats' },
+            ],
+            // is called when a suggestion starts
+            onEnter: ({
+              items, query, range, command, virtualNode,
+            }) => {
+              this.query = query
+              this.filteredUsers = items
+              this.suggestionRange = range
+              this.renderPopup(virtualNode)
+              // we save the command for inserting a selected mention
+              // this allows us to call it inside of our custom popup
+              // via keyboard navigation and on click
+              this.insertMention = command
+            },
+            // is called when a suggestion has changed
+            onChange: ({
+              items, query, range, virtualNode,
+            }) => {
+              this.query = query
+              this.filteredUsers = items
+              this.suggestionRange = range
+              this.navigatedUserIndex = 0
+              this.renderPopup(virtualNode)
+            },
+            // is called when a suggestion is cancelled
+            onExit: () => {
+              // reset all saved values
+              this.query = null
+              this.filteredUsers = []
+              this.suggestionRange = null
+              this.navigatedUserIndex = 0
+              this.destroyPopup()
+            },
+            // is called on every keyDown event while a suggestion is active
+            onKeyDown: ({ event }) => {
+              // pressing up arrow
+              if (event.keyCode === 38) {
+                this.upHandler()
+                return true
+              }
+              // pressing down arrow
+              if (event.keyCode === 40) {
+                this.downHandler()
+                return true
+              }
+              // pressing enter
+              if (event.keyCode === 13) {
+                this.enterHandler()
+                return true
+              }
+
+              return false
+            },
+            // is called when a suggestion has changed
+            // this function is optional because there is basic filtering built-in
+            // you can overwrite it if you prefer your own filtering
+            // in this example we use fuse.js with support for fuzzy search
+            onFilter: (items, query) => {
+              if (!query) {
+                return items
+              }
+
+              const fuse = new Fuse(items, {
+                threshold: 0.2,
+                keys: ['name'],
+              })
+
+              return fuse.search(query)
+            },
+          }),
           new Code(),
           new Bold(),
           new Italic(),
@@ -150,7 +235,7 @@ export default {
             Sometimes it's useful to <strong>mention</strong> someone. That's a feature we're very used to. Under the hood this technique can also be used for other features likes <strong>hashtags</strong> and <strong>commands</strong> – lets call it <em>suggestions</em>.
           </p>
           <p>
-            This is an example how to mention some users like <span data-mention-id="1">Philipp Kühn</span> or <span data-mention-id="2">Hans Pagel</span>. Try to type <code>@</code> and a popup (rendered with tippy.js) will appear. You can navigate with arrow keys through a list of suggestions.
+            This is an example how to mention some users and hashtags like <span data-mention-id="1" data-mention-tag="default">Philipp Kühn</span> or <span data-mention-id="2" data-mention-tag="hashtag">Dogs</span>. Try to type <code>@</code> or <code>#</code> and a popup (rendered with tippy.js) will appear. You can navigate with arrow keys through a list of suggestions.
           </p>
         `,
       }),
@@ -173,7 +258,6 @@ export default {
     },
 
   },
-
   methods: {
 
     // navigate to the previous item

--- a/examples/Components/Routes/Suggestions/index.vue
+++ b/examples/Components/Routes/Suggestions/index.vue
@@ -146,7 +146,7 @@ export default {
             matcher: {
               char: '#',
             },
-            tag: 'hashtag',
+            type: 'hashtag',
             // a list of all suggested items
             items: () => [
               { id: 1, name: 'Dogs' },

--- a/packages/tiptap-extensions/src/nodes/Mention.js
+++ b/packages/tiptap-extensions/src/nodes/Mention.js
@@ -5,7 +5,7 @@ import SuggestionsPlugin from '../plugins/Suggestions'
 export default class Mention extends Node {
 
   get name() {
-    return `mention-${this.options.matcher.char}`
+    return this.options.tag === 'default' ? 'mention' : `mention_${this.options.tag}`
   }
 
   get defaultOptions() {
@@ -15,6 +15,7 @@ export default class Mention extends Node {
         allowSpaces: false,
         startOfLine: false,
       },
+      tag: 'default',
       mentionClass: 'mention',
       suggestionClass: 'mention-suggestion',
     }
@@ -35,16 +36,18 @@ export default class Mention extends Node {
         {
           class: this.options.mentionClass,
           'data-mention-id': node.attrs.id,
+          'data-mention-tag': this.options.tag,
         },
         `${this.options.matcher.char}${node.attrs.label}`,
       ],
       parseDOM: [
         {
-          tag: 'span[data-mention-id]',
+          tag: `span[data-mention-tag=${this.options.tag}]`,
           getAttrs: dom => {
             const id = dom.getAttribute('data-mention-id')
+            const tag = dom.getAttribute('data-mention-tag')
             const label = dom.innerText.split(this.options.matcher.char).join('')
-            return { id, label }
+            return { id, label, tag }
           },
         },
       ],

--- a/packages/tiptap-extensions/src/nodes/Mention.js
+++ b/packages/tiptap-extensions/src/nodes/Mention.js
@@ -5,7 +5,7 @@ import SuggestionsPlugin from '../plugins/Suggestions'
 export default class Mention extends Node {
 
   get name() {
-    return 'mention'
+    return `mention-${this.options.matcher.char}`
   }
 
   get defaultOptions() {

--- a/packages/tiptap-extensions/src/nodes/Mention.js
+++ b/packages/tiptap-extensions/src/nodes/Mention.js
@@ -5,7 +5,7 @@ import SuggestionsPlugin from '../plugins/Suggestions'
 export default class Mention extends Node {
 
   get name() {
-    return this.options.tag === 'default' ? 'mention' : `mention_${this.options.tag}`
+    return this.options.type === 'default' ? 'mention' : `mention_${this.options.type}`
   }
 
   get defaultOptions() {
@@ -15,7 +15,7 @@ export default class Mention extends Node {
         allowSpaces: false,
         startOfLine: false,
       },
-      tag: 'default',
+      type: 'default',
       mentionClass: 'mention',
       suggestionClass: 'mention-suggestion',
     }
@@ -36,18 +36,18 @@ export default class Mention extends Node {
         {
           class: this.options.mentionClass,
           'data-mention-id': node.attrs.id,
-          'data-mention-tag': this.options.tag,
+          'data-mention-type': this.options.type,
         },
         `${this.options.matcher.char}${node.attrs.label}`,
       ],
       parseDOM: [
         {
-          tag: `span[data-mention-tag=${this.options.tag}]`,
+          type: `span[data-mention-type=${this.options.type}]`,
           getAttrs: dom => {
             const id = dom.getAttribute('data-mention-id')
-            const tag = dom.getAttribute('data-mention-tag')
+            const type = dom.getAttribute('data-mention-type')
             const label = dom.innerText.split(this.options.matcher.char).join('')
-            return { id, label, tag }
+            return { id, label, type }
           },
         },
       ],


### PR DESCRIPTION
There needs to be a unique identifier for registered mentions when using multiple instances with different matcher characters. Otherwise the `mention` node in the schema is overwritten by the last registered `Mention` instance