### PR TITLE
Make placeholder text configurable

### DIFF
--- a/examples/Components/Routes/Placeholder/index.vue
+++ b/examples/Components/Routes/Placeholder/index.vue
@@ -24,6 +24,7 @@ export default {
           new ListItem(),
           new Placeholder({
             emptyClass: 'is-empty',
+            placeholderText: 'Start typing...'
           }),
         ],
       }),
@@ -37,7 +38,7 @@ export default {
 
 <style lang="scss">
 .editor p.is-empty:first-child::before {
-  content: 'Start typing…';
+  content: attr(data-placeholder);
   float: left;
   color: #aaa;
   pointer-events: none;

--- a/packages/tiptap-extensions/src/extensions/Placeholder.js
+++ b/packages/tiptap-extensions/src/extensions/Placeholder.js
@@ -10,6 +10,7 @@ export default class Placeholder extends Extension {
   get defaultOptions() {
     return {
       emptyNodeClass: 'is-empty',
+      placeholderText: 'Start typing...',
     }
   }
 
@@ -28,6 +29,7 @@ export default class Placeholder extends Extension {
 
               const decoration = Decoration.node(pos, pos + node.nodeSize, {
                 class: this.options.emptyNodeClass,
+                'data-placeholder': this.options.placeholderText,
               })
               decorations.push(decoration)
             })


### PR DESCRIPTION
The placeholder text can be configured upon creation of Placeholder Plugin.

Reactivity is not implemented yet. I don't know if it's currently possible to pass dynamic config to Plugins?

Closes #114 