### PR TITLE
Update examples.js

### DIFF
--- a/examples/Components/Routes/CodeHighlighting/examples.js
+++ b/examples/Components/Routes/CodeHighlighting/examples.js
@@ -30,6 +30,9 @@ body, .usertext {
 
 export const ExplicitImportExample = `import javascript from 'highlight.js/lib/languages/javascript'
 import { Editor } from 'tiptap'
+import {
+  CodeBlockHighlight,
+} from 'tiptap-extensions'
 
 export default {
   components: {
@@ -38,7 +41,7 @@ export default {
   data() {
     return {
       extensions: [
-        new CodeBlockHighlightNode({
+        new CodeBlockHighlight({
           languages: {
             javascript,
             css,

--- a/examples/Components/Routes/CodeHighlighting/examples.js
+++ b/examples/Components/Routes/CodeHighlighting/examples.js
@@ -29,6 +29,7 @@ body, .usertext {
 
 
 export const ExplicitImportExample = `import javascript from 'highlight.js/lib/languages/javascript'
+import css from 'highlight.js/lib/languages/css'
 import { Editor } from 'tiptap'
 import {
   CodeBlockHighlight,


### PR DESCRIPTION
I stumbled upon the [documentation "Code Highlighting"](https://tiptap.scrumpy.io/code-highlighting), it confused me. 
It looks like it should be as I fixed if you rely on [this code](https://github.com/scrumpy/tiptap/blob/21c8ad852a8cf6602153948ffe40415794a318a4/examples/Components/Routes/CodeHighlighting/index.vue).

Also, the highlighting did not work for me until I connected one of the themes:
```js
import 'highlight.js/styles/github.css'
```
This is if I do not copy styles that are in the `<style>` tag for the second link.
