### PR TITLE
Markdown paste support.

### DIFF
--- a/packages/tiptap-commands/src/commands/markPasteRule.js
+++ b/packages/tiptap-commands/src/commands/markPasteRule.js
@@ -1,0 +1,57 @@
+import { Plugin } from 'prosemirror-state'
+import { Slice, Fragment } from 'prosemirror-model'
+
+export default function (regexp, type, getAttrs) {
+
+  const handler = fragment => {
+    const nodes = []
+
+    fragment.forEach(child => {
+      if (child.isText) {
+        const { text } = child
+        let pos = 0
+        let match
+
+        // eslint-disable-next-line
+        while ((match = regexp.exec(text)) !== null) {
+          if (match[1]) {
+            const start = match.index
+            const end = start + match[0].length
+            const textStart = start + match[0].indexOf(match[1])
+            const textEnd = textStart + match[1].length
+            const attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs
+
+            // adding text before markdown to nodes
+            if (start > 0) {
+              nodes.push(child.cut(pos, start))
+            }
+
+            // adding the markdown part to nodes
+            nodes.push(child
+              .cut(textStart, textEnd)
+              .mark(type.create(attrs)
+              .addToSet(child.marks)))
+
+            pos = end
+          }
+        }
+
+        // adding rest of text to nodes
+        if (pos < text.length) {
+          nodes.push(child.cut(pos))
+        }
+      } else {
+        nodes.push(child.copy(handler(child.content)))
+      }
+    })
+
+    return Fragment.fromArray(nodes)
+  }
+
+  return new Plugin({
+    props: {
+      transformPasted: slice => new Slice(handler(slice.content), slice.openStart, slice.openEnd),
+    },
+  })
+
+}

--- a/packages/tiptap-commands/src/index.js
+++ b/packages/tiptap-commands/src/index.js
@@ -41,6 +41,7 @@ import {
 import insertText from './commands/insertText'
 import markInputRule from './commands/markInputRule'
 import pasteRule from './commands/pasteRule'
+import markPasteRule from './commands/markPasteRule'
 import removeMark from './commands/removeMark'
 import replaceText from './commands/replaceText'
 import setInlineBlockType from './commands/setInlineBlockType'
@@ -91,6 +92,7 @@ export {
   // custom
   insertText,
   markInputRule,
+  markPasteRule,
   pasteRule,
   removeMark,
   replaceText,

--- a/packages/tiptap-extensions/src/marks/Bold.js
+++ b/packages/tiptap-extensions/src/marks/Bold.js
@@ -1,5 +1,5 @@
 import { Mark } from 'tiptap'
-import { toggleMark, markInputRule } from 'tiptap-commands'
+import { toggleMark, markInputRule, markPasteRule } from 'tiptap-commands'
 
 export default class Bold extends Mark {
 
@@ -39,6 +39,12 @@ export default class Bold extends Mark {
   inputRules({ type }) {
     return [
       markInputRule(/(?:\*\*|__)([^*_]+)(?:\*\*|__)$/, type),
+    ]
+  }
+
+  pasteRules({ type }) {
+    return [
+      markPasteRule(/(?:\*\*|__)([^*_]+)(?:\*\*|__)/g, type),
     ]
   }
 

--- a/packages/tiptap-extensions/src/marks/Code.js
+++ b/packages/tiptap-extensions/src/marks/Code.js
@@ -1,5 +1,5 @@
 import { Mark } from 'tiptap'
-import { toggleMark, markInputRule } from 'tiptap-commands'
+import { toggleMark, markInputRule, markPasteRule } from 'tiptap-commands'
 
 export default class Code extends Mark {
 
@@ -29,6 +29,12 @@ export default class Code extends Mark {
   inputRules({ type }) {
     return [
       markInputRule(/(?:`)([^`]+)(?:`)$/, type),
+    ]
+  }
+
+  pasteRules({ type }) {
+    return [
+      markPasteRule(/(?:`)([^`]+)(?:`)/g, type),
     ]
   }
 

--- a/packages/tiptap-extensions/src/marks/Italic.js
+++ b/packages/tiptap-extensions/src/marks/Italic.js
@@ -1,5 +1,5 @@
 import { Mark } from 'tiptap'
-import { toggleMark, markInputRule } from 'tiptap-commands'
+import { toggleMark, markInputRule, markPasteRule } from 'tiptap-commands'
 
 export default class Italic extends Mark {
 
@@ -31,6 +31,12 @@ export default class Italic extends Mark {
   inputRules({ type }) {
     return [
       markInputRule(/(?:^|[^*_])(?:\*|_)([^*_]+)(?:\*|_)$/, type),
+    ]
+  }
+
+  pasteRules({ type }) {
+    return [
+      markPasteRule(/(?:^|[^*_])(?:\*|_)([^*_]+)(?:\*|_)/g, type),
     ]
   }
 

--- a/packages/tiptap-extensions/src/marks/Strike.js
+++ b/packages/tiptap-extensions/src/marks/Strike.js
@@ -1,5 +1,5 @@
 import { Mark } from 'tiptap'
-import { toggleMark, markInputRule } from 'tiptap-commands'
+import { toggleMark, markInputRule, markPasteRule } from 'tiptap-commands'
 
 export default class Strike extends Mark {
 
@@ -41,6 +41,12 @@ export default class Strike extends Mark {
   inputRules({ type }) {
     return [
       markInputRule(/~([^~]+)~$/, type),
+    ]
+  }
+
+  pasteRules({ type }) {
+    return [
+      markPasteRule(/~([^~]+)~/g, type),
     ]
   }
 

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -31,6 +31,7 @@ export default class Editor {
       onUpdate: () => {},
       onFocus: () => {},
       onBlur: () => {},
+      onPaste: () => {},
     }
 
     this.init(options)
@@ -198,6 +199,8 @@ export default class Editor {
   createView() {
     const view = new EditorView(this.element, {
       state: this.state,
+      handlePaste: this.options.onPaste,
+      handleDrop: this.options.onPaste,
       dispatchTransaction: this.dispatchTransaction.bind(this),
     })
 

--- a/packages/tiptap/src/Utils/Extension.js
+++ b/packages/tiptap/src/Utils/Extension.js
@@ -27,6 +27,10 @@ export default class Extension {
     return []
   }
 
+  pasteRules() {
+    return []
+  }
+
   keys() {
     return {}
   }


### PR DESCRIPTION
Allow pasting of markdown in editor via pasteRules.

### ToDo
- [x] Marks
  - [x] Bold
  - [x] Code
  - [x] Italic
  - [x] Strike
- [ ] Nodes
  - [ ] Blockquote
  - [ ] BulletList
  - [ ] CodeBlock
  - [ ] CodeBlockHighlight
  - [ ] Heading
  - [ ] HorizontalRule
  - [ ] Image
  - [ ] ListItem
  - [ ] Mention
  - [ ] OrderedList
  - [ ] TodoItem
  - [ ] TodoList
  - [ ] Tables

Also I am unable to get nested marks to work like:
`___bold and italic___` ___bold and italic___

This should fix #182