### PR TITLE
added markdown rule for horizontal line

### DIFF
--- a/packages/tiptap-commands/src/commands/nodeInputRule.js
+++ b/packages/tiptap-commands/src/commands/nodeInputRule.js
@@ -1,0 +1,14 @@
+import { InputRule } from 'prosemirror-inputrules'
+
+export default function (regexp, type, getAttrs) {
+  return new InputRule(regexp, (state, match, start, end) => {
+    const attrs = getAttrs instanceof Function ? getAttrs(match) : getAttrs
+    const { tr } = state
+
+    if (match[0]) {
+      tr.replaceWith(start - 1, end, type.create(attrs))
+    }
+
+    return tr
+  })
+}

--- a/packages/tiptap-commands/src/index.js
+++ b/packages/tiptap-commands/src/index.js
@@ -40,6 +40,7 @@ import {
 
 import insertText from './commands/insertText'
 import markInputRule from './commands/markInputRule'
+import nodeInputRule from './commands/nodeInputRule'
 import pasteRule from './commands/pasteRule'
 import removeMark from './commands/removeMark'
 import replaceText from './commands/replaceText'
@@ -91,6 +92,7 @@ export {
   // custom
   insertText,
   markInputRule,
+  nodeInputRule,
   pasteRule,
   removeMark,
   replaceText,

--- a/packages/tiptap-extensions/src/nodes/HorizontalRule.js
+++ b/packages/tiptap-extensions/src/nodes/HorizontalRule.js
@@ -1,4 +1,5 @@
 import { Node } from 'tiptap'
+import { nodeInputRule } from 'tiptap-commands'
 
 export default class HorizontalRule extends Node {
   get name() {
@@ -15,5 +16,11 @@ export default class HorizontalRule extends Node {
 
   commands({ type }) {
     return () => (state, dispatch) => dispatch(state.tr.replaceSelectionWith(type.create()))
+  }
+
+  inputRules({ type }) {
+    return [
+      nodeInputRule(/^(?:---|___\s|\*\*\*\s)$/, type),
+    ]
   }
 }


### PR DESCRIPTION
This allows to use `---` as an alias for a `<hr />`

Also `___` and `***` are supprted but must be terminated with a space to take effect, otherwise __bold__ and _italic_ won't work at start of line.