### PR TITLE
seperate handleDrop from handlePaste

### DIFF
--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -32,6 +32,7 @@ export default class Editor {
       onFocus: () => {},
       onBlur: () => {},
       onPaste: () => {},
+      onDrop: () => {},
     }
 
     this.init(options)
@@ -209,7 +210,7 @@ export default class Editor {
     const view = new EditorView(this.element, {
       state: this.state,
       handlePaste: this.options.onPaste,
-      handleDrop: this.options.onPaste,
+      handleDrop: this.options.onDrop,
       dispatchTransaction: this.dispatchTransaction.bind(this),
     })
 


### PR DESCRIPTION
Because sometimes you maybe just want to handle drop events 😅

This will however break if someone uses `onPaste` to stop drop events.