### PR TITLE
Fix link example

### DIFF
--- a/examples/Components/Routes/Links/index.vue
+++ b/examples/Components/Routes/Links/index.vue
@@ -21,7 +21,7 @@
             @click="showLinkMenu(getMarkAttrs('link'))"
             :class="{ 'is-active': isActive.link() }"
           >
-            <span>Add Link</span>
+            <span>{{ isActive.link() ? 'Update Link' : 'Add Link'}}</span>
             <icon name="link" />
           </button>
         </template>

--- a/examples/Components/Routes/Links/index.vue
+++ b/examples/Components/Routes/Links/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="editor">
-    <editor-menu-bubble class="menububble" :editor="editor">
+    <editor-menu-bubble class="menububble" :editor="editor" @hide="hideLinkMenu">
       <div
         slot-scope="{ commands, isActive, getMarkAttrs, menu }"
         class="menububble"

--- a/packages/tiptap/src/Components/EditorMenuBubble.js
+++ b/packages/tiptap/src/Components/EditorMenuBubble.js
@@ -28,6 +28,12 @@ export default {
             editor.registerPlugin(MenuBubble({
               element: this.$el,
               onUpdate: menu => {
+                // the second check ensures event is fired only once
+                if (menu.isActive && this.menu.isActive === false) {
+                  this.$emit('show', menu)
+                } else if (!menu.isActive && this.menu.isActive === true) {
+                  this.$emit('hide', menu)
+                }
                 this.menu = menu
               },
             }))


### PR DESCRIPTION
Currently the link example is a little bit confusing from a user perspective. 
Clicking on one link and editing it and then clicking on another link keeps the old link in memory.

This **PR** introduced `hide` and `show` events on the menu-bubble component

## The bug
![link-bug](https://user-images.githubusercontent.com/6141652/53088406-e84f4e00-3509-11e9-81f2-896f1a5063b7.gif)

## Fixed
![link-fixed](https://user-images.githubusercontent.com/6141652/53088425-f604d380-3509-11e9-93c0-6ab4f3118c3b.gif)

