### PR TITLE
Reactive extension options

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ The most powerful feature of tiptap is that you can create your own extensions. 
 | `commands({ schema, attrs })` | `Object` | `null` | Define a command. |
 | `inputRules({ schema })` | `Array` | `[]` | Define a list of input rules. |
 | `pasteRules({ schema })` | `Array` | `[]` | Define a list of paste rules. |
+| `get update()` | `Function` | `undefined` | Called when options of extension are changed via `editor.extensions.options` |
 
 ### Node|Mark Class
 

--- a/examples/Components/Routes/Placeholder/index.vue
+++ b/examples/Components/Routes/Placeholder/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="editor">
+    <input type="text" v-model="placeholder">
     <editor-content class="editor__content" :editor="editor" />
   </div>
 </template>
@@ -18,6 +19,7 @@ export default {
   },
   data() {
     return {
+      placeholder: 'Write something …',
       editor: new Editor({
         extensions: [
           new BulletList(),
@@ -33,6 +35,11 @@ export default {
   },
   beforeDestroy() {
     this.editor.destroy()
+  },
+  watch: {
+    placeholder(newValue) {
+      this.editor.extensions.options.placeholder.emptyNodeText = newValue
+    },
   },
 }
 </script>

--- a/packages/tiptap-extensions/src/extensions/Placeholder.js
+++ b/packages/tiptap-extensions/src/extensions/Placeholder.js
@@ -16,9 +16,8 @@ export default class Placeholder extends Extension {
   }
 
   get update() {
-    return ({ state, view }) => {
-      // TODO: fix error when content is not empty
-      view.updateState(state)
+    return view => {
+      view.updateState(view.state)
     }
   }
 

--- a/packages/tiptap-extensions/src/extensions/Placeholder.js
+++ b/packages/tiptap-extensions/src/extensions/Placeholder.js
@@ -15,6 +15,13 @@ export default class Placeholder extends Extension {
     }
   }
 
+  get update() {
+    return ({ state, view }) => {
+      // TODO: fix error when content is not empty
+      view.updateState(state)
+    }
+  }
+
   get plugins() {
     return [
       new Plugin({

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -68,8 +68,7 @@ export default class Editor {
       state: this.state,
     })
 
-    // give extension manager access to our view and state
-    this.extensions.state = this.state
+    // give extension manager access to our view
     this.extensions.view = this.view
   }
 

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -67,6 +67,10 @@ export default class Editor {
       view: this.view,
       state: this.state,
     })
+
+    // give extension manager access to our view and state
+    this.extensions.state = this.state
+    this.extensions.view = this.view
   }
 
   setOptions(options) {

--- a/packages/tiptap/src/Utils/Extension.js
+++ b/packages/tiptap/src/Utils/Extension.js
@@ -15,6 +15,10 @@ export default class Extension {
     return 'extension'
   }
 
+  get update() {
+    return () => {}
+  }
+
   get defaultOptions() {
     return {}
   }

--- a/packages/tiptap/src/Utils/ExtensionManager.js
+++ b/packages/tiptap/src/Utils/ExtensionManager.js
@@ -15,6 +15,28 @@ export default class ExtensionManager {
       }), {})
   }
 
+  get options() {
+    const { state, view } = this
+    return this.extensions
+        // { name, options, update = () => {} }
+        .reduce((nodes, extension) => ({
+          ...nodes,
+          [extension.name]: new Proxy(extension.options, {
+            set(obj, prop, value) {
+              const changed = (obj[prop] !== value)
+
+              obj[prop] = value
+
+              if (changed) {
+                extension.update({ state, view })
+              }
+
+              return true
+            },
+          }),
+        }), {})
+  }
+
   get marks() {
     return this.extensions
       .filter(extension => extension.type === 'mark')

--- a/packages/tiptap/src/Utils/ExtensionManager.js
+++ b/packages/tiptap/src/Utils/ExtensionManager.js
@@ -18,7 +18,6 @@ export default class ExtensionManager {
   get options() {
     const { view } = this
     return this.extensions
-        // { name, options, update = () => {} }
         .reduce((nodes, extension) => ({
           ...nodes,
           [extension.name]: new Proxy(extension.options, {

--- a/packages/tiptap/src/Utils/ExtensionManager.js
+++ b/packages/tiptap/src/Utils/ExtensionManager.js
@@ -24,7 +24,7 @@ export default class ExtensionManager {
             set(obj, prop, value) {
               const changed = (obj[prop] !== value)
 
-              obj[prop] = value
+              Object.assign(obj, { [prop]: value })
 
               if (changed) {
                 extension.update(view)

--- a/packages/tiptap/src/Utils/ExtensionManager.js
+++ b/packages/tiptap/src/Utils/ExtensionManager.js
@@ -16,7 +16,7 @@ export default class ExtensionManager {
   }
 
   get options() {
-    const { state, view } = this
+    const { view } = this
     return this.extensions
         // { name, options, update = () => {} }
         .reduce((nodes, extension) => ({
@@ -28,7 +28,7 @@ export default class ExtensionManager {
               obj[prop] = value
 
               if (changed) {
-                extension.update({ state, view })
+                extension.update(view)
               }
 
               return true


### PR DESCRIPTION
This allows something like this which will call the update method of that extensions.
```js
this.editor.extensions.options.placeholder.emptyNodeText = newValue
```

This will close #153 

# Example
![placeholder](https://user-images.githubusercontent.com/6141652/53408590-27284c80-39bf-11e9-9eb3-ca6c8f30c84e.gif)




# Known Bugs
~~If the content is **not** empty the state get's mismatched, and everything is screwed up 😩~~ fixed with 89e6436 and 0f44e74