### PR TITLE
add extension Tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ import {
   Strike,
   Underline,
   History,
+  Tooltip,
 } from 'tiptap-extensions'
 
 export default {
@@ -263,6 +264,7 @@ export default {
           new Strike(),
           new Underline(),
           new History(),
+          new Tooltip(),
         ],
         content: `
           <h1>Yay Headlines!</h1>

--- a/packages/tiptap-extensions/src/index.js
+++ b/packages/tiptap-extensions/src/index.js
@@ -22,6 +22,7 @@ export { default as Italic } from './marks/Italic'
 export { default as Link } from './marks/Link'
 export { default as Strike } from './marks/Strike'
 export { default as Underline } from './marks/Underline'
+export { default as Tooltip } from './marks/Tooltip'
 
 export { default as History } from './extensions/History'
 export { default as Placeholder } from './extensions/Placeholder'

--- a/packages/tiptap-extensions/src/marks/Tooltip.js
+++ b/packages/tiptap-extensions/src/marks/Tooltip.js
@@ -24,7 +24,7 @@ export default class Tooltip extends Mark {
         },
       ],
       toDOM: node => ['span', {
-        ...node.attrs
+        ...node.attrs,
       }, 0],
     }
   }

--- a/packages/tiptap-extensions/src/marks/Tooltip.js
+++ b/packages/tiptap-extensions/src/marks/Tooltip.js
@@ -39,16 +39,6 @@ export default class Tooltip extends Mark {
     }
   }
 
-  pasteRules({ type }) {
-    return [
-      pasteRule(
-        /.+/g,
-        type,
-        content => ({ tooltip: content }),
-      ),
-    ]
-  }
-
   get plugins() {
     return [
       new Plugin({

--- a/packages/tiptap-extensions/src/marks/Tooltip.js
+++ b/packages/tiptap-extensions/src/marks/Tooltip.js
@@ -1,5 +1,5 @@
 import { Mark, Plugin, TextSelection } from 'tiptap'
-import { updateMark, removeMark, pasteRule } from 'tiptap-commands'
+import { updateMark, removeMark } from 'tiptap-commands'
 import { getMarkRange } from 'tiptap-utils'
 
 export default class Tooltip extends Mark {

--- a/packages/tiptap-extensions/src/marks/Tooltip.js
+++ b/packages/tiptap-extensions/src/marks/Tooltip.js
@@ -1,0 +1,75 @@
+import { Mark, Plugin, TextSelection } from 'tiptap'
+import { updateMark, removeMark, pasteRule } from 'tiptap-commands'
+import { getMarkRange } from 'tiptap-utils'
+
+export default class Tooltip extends Mark {
+  get name() {
+    return 'tooltip'
+  }
+
+  get schema() {
+    return {
+      attrs: {
+        tooltip: {
+          default: null,
+        },
+      },
+      inclusive: false,
+      parseDOM: [
+        {
+          tag: 'span[tooltip]',
+          getAttrs: dom => ({
+            tooltip: dom.getAttribute('tooltip'),
+          }),
+        },
+      ],
+      toDOM: node => ['span', {
+        ...node.attrs
+      }, 0],
+    }
+  }
+
+  commands({ type }) {
+    return attrs => {
+      if (attrs.tooltip) {
+        return updateMark(type, attrs)
+      }
+
+      return removeMark(type)
+    }
+  }
+
+  pasteRules({ type }) {
+    return [
+      pasteRule(
+        /.+/g,
+        type,
+        content => ({ tooltip: content }),
+      ),
+    ]
+  }
+
+  get plugins() {
+    return [
+      new Plugin({
+        props: {
+          handleClick(view, pos) {
+            const { schema, doc, tr } = view.state
+            const range = getMarkRange(doc.resolve(pos), schema.marks.tooltip)
+
+            if (!range) {
+              return
+            }
+
+            const $start = doc.resolve(range.from)
+            const $end = doc.resolve(range.to)
+            const transaction = tr.setSelection(new TextSelection($start, $end))
+
+            view.dispatch(transaction)
+          },
+        },
+      }),
+    ]
+  }
+
+}


### PR DESCRIPTION
- Code is similar to extension Link.
- Wrap `<span tooltip=""></span>` to target text.
- Can use css like [this](https://chrisbracco.com/a-simple-css-tooltip/) to render tooltip.
- fix #236 