### PR TITLE
fix(MenuBubble): MenuBubble doesn't update position when it resizes

### DIFF
--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -21,7 +21,11 @@ class Menu {
 
   startObservingSize() {
     if(window && window.ResizeObserver)
-      this.observer = new ResizeObserver(() => this.reposition(this.editorView)).observe(this.options.element)
+      this.observer = new ResizeObserver(() => {
+        this.reposition(this.editorView)
+        this.sendUpdate()
+      })
+      this.observer.observe(this.options.element)
   }
 
   stopObservingSize() {
@@ -47,7 +51,6 @@ class Menu {
     // console.log(`${left} - ${box.left} > ${el.width} / 2`, left - box.left, el.width / 2)
     this.left = parseInt(left - box.left, 10)
     this.bottom = parseInt(box.bottom - start.top, 10)
-    this.sendUpdate()
   }
 
   update(view, lastState) {


### PR DESCRIPTION
fix(MenuBubble): MenuBubble doesn't stay within bounding box of editor

## BUG
The menu bubble will not detect proper left alignment because of translateX(-50%)
In links demo the menu bubble resizes to show link form, this also causes offset issues.

![UxPnkqxUiv](https://user-images.githubusercontent.com/1056055/54537271-9f53b380-4968-11e9-9c6b-34a39f377b81.gif)

## FIXED

![N4X8MnQwb9](https://user-images.githubusercontent.com/1056055/54537292-a7abee80-4968-11e9-8b4a-7b28d9f6617f.gif)

## Missing

- [ ] Does not handle right alignment issues
- [ ] Will cause conflicts with #228

