### PR TITLE
build: different module `output.name`

### DIFF
--- a/build/packages/config.js
+++ b/build/packages/config.js
@@ -41,7 +41,7 @@ function genConfig(opts) {
       file: opts.file,
       format: opts.format,
       banner,
-      name: 'tiptap',
+      name: opts.outputName,
     },
   }
 
@@ -57,18 +57,22 @@ function genConfig(opts) {
 export default [
   {
     package: 'tiptap',
+    outputName: 'tiptap',
     outputFileName: 'tiptap',
   },
   {
     package: 'tiptap-commands',
+    outputName: 'tiptapCommands',
     outputFileName: 'commands',
   },
   {
     package: 'tiptap-utils',
+    outputName: 'tiptapUtils',
     outputFileName: 'utils',
   },
   {
     package: 'tiptap-extensions',
+    outputName: 'tiptapExtensions',
     outputFileName: 'extensions',
   },
 ].map(item => [


### PR DESCRIPTION
Hi, you did a good package, great job! 

At the moment I am developing my package based on yours. But I had a little problem.

I make a package that uses `tiptap` and `tiptap-extensions` packages.  But these two packages are written in one variable - `tiptap`. 

In my rollup config in `output -> globals` I have to specify two different names, not

```
globals: {
  'tiptap': 'tiptap',
  'tiptap-extensions': 'tiptap'
}
```

Would be right:

```
globals: {
  'tiptap': 'tiptap',
  'tiptap-extensions': 'tiptapExtensions'
}
```

My PR removes the problem with the name (variables) conflict when you use the _UMD_ module as _IIFE_.


