### PR TITLE
allow parseOptions to be passed to setContent and Editor constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ export default {
 | `extensions` | `Array` | `[]` | A list of extensions used, by the editor. This can be `Nodes`, `Marks` or `Plugins`. |
 | `useBuiltInExtensions` | `Boolean` | `true` | By default tiptap adds a `Doc`, `Paragraph` and `Text` node to the Prosemirror schema. |
 | `dropCursor` | `Object` | `{}` | Config for `prosemirror-dropcursor`. |
+| `dropCursor` | `Object` | `{}` | A list of [Prosemirror parseOptions](https://prosemirror.net/docs/ref/#model.ParseOptions). |
 | `onInit` | `Function` | `undefined` | This will return an Object with the current `state` and `view` of Prosemirror on init. |
 | `onFocus` | `Function` | `undefined` | This will return an Object with the `event` and current `state` and `view` of Prosemirror on focus. |
 | `onBlur` | `Function` | `undefined` | This will return an Object with the `event` and current `state` and `view` of Prosemirror on blur. |
@@ -81,7 +82,7 @@ export default {
 
 | **Method** | **Arguments**| **Description** |
 | --- | :---: | --- |
-| `setContent` | `content, emitUpdate` | Replace the current content. You can pass an HTML string or a JSON document. `emitUpdate` defaults to `false`. |
+| `setContent` | `content, emitUpdate, parseOptions` | Replace the current content. You can pass an HTML string or a JSON document. `emitUpdate` defaults to `false`. `parseOptions` defaults to those provided in constructor. |
 | `clearContent` | `emitUpdate` | Clears the current content. `emitUpdate` defaults to `false`. |
 | `setOptions` | `options` | Overwrites the current editor properties. |
 | `registerPlugin` | `plugin` | Register a Prosemirror plugin. |

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -27,6 +27,7 @@ export default class Editor {
       },
       useBuiltInExtensions: true,
       dropCursor: {},
+      parseOptions: {},
       onInit: () => {},
       onUpdate: () => {},
       onFocus: () => {},
@@ -185,7 +186,7 @@ export default class Editor {
     })
   }
 
-  createDocument(content) {
+  createDocument(content, parseOptions = this.options.parseOptions) {
     if (content === null) {
       return this.schema.nodeFromJSON(this.options.emptyDocument)
     }
@@ -203,7 +204,7 @@ export default class Editor {
       const element = document.createElement('div')
       element.innerHTML = content.trim()
 
-      return DOMParser.fromSchema(this.schema).parse(element)
+      return DOMParser.fromSchema(this.schema).parse(element, parseOptions)
     }
 
     return false
@@ -321,10 +322,10 @@ export default class Editor {
     return this.state.doc.toJSON()
   }
 
-  setContent(content = {}, emitUpdate = false) {
+  setContent(content = {}, emitUpdate = false, parseOptions) {
     this.state = EditorState.create({
       schema: this.state.schema,
-      doc: this.createDocument(content),
+      doc: this.createDocument(content, parseOptions),
       plugins: this.state.plugins,
     })
 

--- a/packages/tiptap/test/Editor.spec.js
+++ b/packages/tiptap/test/Editor.spec.js
@@ -278,3 +278,52 @@ test('update callback', done => {
 
   editor.setContent('<p>Bar</p>', true)
 })
+
+test('parse options in set content', done => {
+  const editor = new Editor({
+    content: '<p>Foo</p>',
+    onUpdate: ({ getHTML, getJSON }) => {
+      expect(getHTML()).toEqual('<p>  Foo  </p>')
+      expect(getJSON()).toEqual({
+        type: 'doc',
+        content: [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                text: '  Foo  ',
+              },
+            ],
+          },
+        ],
+      })
+      done()
+    },
+  })
+
+  editor.setContent('<p>  Foo  </p>', true, { preserveWhitespace: true })
+})
+
+test('parse options in constructor', () => {
+  const editor = new Editor({
+    content: '<p>  Foo  </p>',
+    parseOptions: { preserveWhitespace: true },
+  })
+
+  expect(editor.getHTML()).toEqual('<p>  Foo  </p>')
+  expect(editor.getJSON()).toEqual({
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [
+          {
+            type: 'text',
+            text: '  Foo  ',
+          },
+        ],
+      },
+    ],
+  })
+})


### PR DESCRIPTION
As requested in #168, I added the possibility to pass `parserOptions` to both the `Editor` constructor and when calling `.setContent()`.  Passing to the constructor was necessary for loading content that contains whitespaces which need to be preserved.