### PR TITLE
Allow extensions to override stopEvent

### DIFF
--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -108,6 +108,10 @@ export default class ComponentView {
 
   // disable (almost) all prosemirror event listener for node views
   stopEvent(event) {
+    if (typeof this.extension.stopEvent === 'function') {
+      return this.extension.stopEvent(event)
+    }
+
     const isPaste = event.type === 'paste'
     const draggable = !!this.extension.schema.draggable
 


### PR DESCRIPTION
This PR addresses #217 

While the modifications linked in that issue describes a solution to fix drag events in general, this PR lets you just override it completely. This way, if you really need to change the behavior, go for it.