### PR TITLE
add option to disable input/pasterules

### DIFF
--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -31,8 +31,8 @@ export default class Editor {
         }],
       },
       useBuiltInExtensions: true,
-      disabledInputRules: [],
-      disabledPasteRules: [],
+      disableInputRules: false,
+      disablePasteRules: false,
       dropCursor: {},
       parseOptions: {},
       onInit: () => {},
@@ -123,14 +123,14 @@ export default class Editor {
   createInputRules() {
     return this.extensions.inputRules({
       schema: this.schema,
-      excludedExtensions: this.options.disabledInputRules,
+      excludedExtensions: this.options.disableInputRules,
     })
   }
 
   createPasteRules() {
     return this.extensions.pasteRules({
       schema: this.schema,
-      excludedExtensions: this.options.disabledPasteRules,
+      excludedExtensions: this.options.disablePasteRules,
     })
   }
 

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -31,6 +31,8 @@ export default class Editor {
         }],
       },
       useBuiltInExtensions: true,
+      disabledInputRules: [],
+      disabledPasteRules: [],
       dropCursor: {},
       parseOptions: {},
       onInit: () => {},
@@ -121,12 +123,14 @@ export default class Editor {
   createInputRules() {
     return this.extensions.inputRules({
       schema: this.schema,
+      excludedExtensions: this.options.disabledInputRules,
     })
   }
 
   createPasteRules() {
     return this.extensions.pasteRules({
       schema: this.schema,
+      excludedExtensions: this.options.disabledPasteRules,
     })
   }
 

--- a/packages/tiptap/src/Utils/ExtensionManager.js
+++ b/packages/tiptap/src/Utils/ExtensionManager.js
@@ -74,13 +74,16 @@ export default class ExtensionManager {
     ].map(keys => keymap(keys))
   }
 
-  inputRules({ schema }) {
-    const extensionInputRules = this.extensions
+  inputRules({ schema, excludedExtensions }) {
+    const allowedExtensions = this.extensions
+        .filter(extension => !excludedExtensions.includes(extension.name))
+
+    const extensionInputRules = allowedExtensions
       .filter(extension => ['extension'].includes(extension.type))
       .filter(extension => extension.inputRules)
       .map(extension => extension.inputRules({ schema }))
 
-    const nodeMarkInputRules = this.extensions
+    const nodeMarkInputRules = allowedExtensions
       .filter(extension => ['node', 'mark'].includes(extension.type))
       .filter(extension => extension.inputRules)
       .map(extension => extension.inputRules({
@@ -97,13 +100,16 @@ export default class ExtensionManager {
     ]), [])
   }
 
-  pasteRules({ schema }) {
-    const extensionPasteRules = this.extensions
+  pasteRules({ schema, excludedExtensions }) {
+    const allowedExtensions = this.extensions
+        .filter(extension => !excludedExtensions.includes(extension.name))
+
+    const extensionPasteRules = allowedExtensions
       .filter(extension => ['extension'].includes(extension.type))
       .filter(extension => extension.pasteRules)
       .map(extension => extension.pasteRules({ schema }))
 
-    const nodeMarkPasteRules = this.extensions
+    const nodeMarkPasteRules = allowedExtensions
       .filter(extension => ['node', 'mark'].includes(extension.type))
       .filter(extension => extension.pasteRules)
       .map(extension => extension.pasteRules({

--- a/packages/tiptap/src/Utils/ExtensionManager.js
+++ b/packages/tiptap/src/Utils/ExtensionManager.js
@@ -75,8 +75,10 @@ export default class ExtensionManager {
   }
 
   inputRules({ schema, excludedExtensions }) {
-    const allowedExtensions = this.extensions
-        .filter(extension => !excludedExtensions.includes(extension.name))
+    if (!(excludedExtensions instanceof Array) && excludedExtensions) return []
+
+    const allowedExtensions = (excludedExtensions instanceof Array) ? this.extensions
+        .filter(extension => !excludedExtensions.includes(extension.name)) : this.extensions
 
     const extensionInputRules = allowedExtensions
       .filter(extension => ['extension'].includes(extension.type))
@@ -101,8 +103,10 @@ export default class ExtensionManager {
   }
 
   pasteRules({ schema, excludedExtensions }) {
-    const allowedExtensions = this.extensions
-        .filter(extension => !excludedExtensions.includes(extension.name))
+    if (!(excludedExtensions instanceof Array) && excludedExtensions) return []
+
+    const allowedExtensions = (excludedExtensions instanceof Array) ? this.extensions
+        .filter(extension => !excludedExtensions.includes(extension.name)) : this.extensions
 
     const extensionPasteRules = allowedExtensions
       .filter(extension => ['extension'].includes(extension.type))


### PR DESCRIPTION
This ads two new options to the editor class to allow input/paste rules to be disabled, by their extension name (`bold`, `italic`, `code_block`, etc.) 

```js
new Editor({
  disabledInputRules: ['bold'],
  disabledPasteRules: ['bold'],
})
```

Fixes #271

_Maybe I'm wrong and this is alredy possible via another setting ([autoInput](https://prosemirror.net/docs/ref/version/0.3.0.html#autoInput)???)_