### PR TITLE
Fix getMarkRange

### DIFF
--- a/packages/tiptap-utils/src/utils/getMarkRange.js
+++ b/packages/tiptap-utils/src/utils/getMarkRange.js
@@ -17,13 +17,14 @@ export default function ($pos = null, type = null) {
 
   let startIndex = $pos.index()
   let startPos = $pos.start() + start.offset
+  let endIndex = startIndex + 1
+  let endPos = startPos + start.node.nodeSize
+
   while (startIndex > 0 && link.isInSet($pos.parent.child(startIndex - 1).marks)) {
     startIndex -= 1
     startPos -= $pos.parent.child(startIndex).nodeSize
   }
 
-  let endIndex = $pos.indexAfter()
-  let endPos = startPos + start.node.nodeSize
   while (endIndex < $pos.parent.childCount && link.isInSet($pos.parent.child(endIndex).marks)) {
     endPos += $pos.parent.child(endIndex).nodeSize
     endIndex += 1

--- a/packages/tiptap-utils/src/utils/getMarkRange.js
+++ b/packages/tiptap-utils/src/utils/getMarkRange.js
@@ -22,7 +22,7 @@ export default function ($pos = null, type = null) {
     startPos -= $pos.parent.child(startIndex).nodeSize
   }
 
-  // const endIndex = $pos.indexAfter()
+  const endIndex = $pos.indexAfter()
   const endPos = startPos + start.node.nodeSize
 
   // disable for now. see #156

--- a/packages/tiptap-utils/src/utils/getMarkRange.js
+++ b/packages/tiptap-utils/src/utils/getMarkRange.js
@@ -22,14 +22,12 @@ export default function ($pos = null, type = null) {
     startPos -= $pos.parent.child(startIndex).nodeSize
   }
 
-  const endIndex = $pos.indexAfter()
-  const endPos = startPos + start.node.nodeSize
-
-  // disable for now. see #156
-  // while (endIndex < $pos.parent.childCount && link.isInSet($pos.parent.child(endIndex).marks)) {
-  //   endPos += $pos.parent.child(endIndex).nodeSize
-  //   endIndex += 1
-  // }
+  let endIndex = $pos.indexAfter()
+  let endPos = startPos + start.node.nodeSize
+  while (endIndex < $pos.parent.childCount && link.isInSet($pos.parent.child(endIndex).marks)) {
+    endPos += $pos.parent.child(endIndex).nodeSize
+    endIndex += 1
+  }
 
   return { from: startPos, to: endPos }
 


### PR DESCRIPTION
reverting fixes for #156 and trying to fix the detection of endPos.

**ATTENTION**
since i cannot reproduce #156 in the first place please verify that this will not reintroduce the issue from #156..

**what use case gets fixed by this?**
having marks like `<a>aaa<b>bbb</b>ccc</a>` will always select `aaa` even if clicking on `ccc`
expected behaviour: when clicking `ccc` `aaabbbcc` will be selected.
