### PR TITLE
do not transform text of pasted links

### DIFF
--- a/examples/Components/Routes/Links/index.vue
+++ b/examples/Components/Routes/Links/index.vue
@@ -72,10 +72,10 @@ export default {
           new OrderedList(),
           new TodoItem(),
           new TodoList(),
+          new Link(),
           new Bold(),
           new Code(),
           new Italic(),
-          new Link(),
           new History(),
         ],
         content: `

--- a/packages/tiptap-commands/src/commands/markPasteRule.js
+++ b/packages/tiptap-commands/src/commands/markPasteRule.js
@@ -8,12 +8,14 @@ export default function (regexp, type, getAttrs) {
 
     fragment.forEach(child => {
       if (child.isText) {
-        const { text } = child
+        const { text, marks } = child
         let pos = 0
         let match
 
+        const isLink = !!marks.filter(x => x.type.name === 'link')[0]
+
         // eslint-disable-next-line
-        while ((match = regexp.exec(text)) !== null) {
+        while (!isLink && (match = regexp.exec(text)) !== null) {
           if (match[1]) {
             const start = match.index
             const end = start + match[0].length


### PR DESCRIPTION
this skips links in markPasteRules (Bold, Italic, Code, Strike, Underline)

fixes #258

works only if link extension is added before mark extensions

    extensions: [
      ...
      new Link(),
      ...
      new Italic(),
      new Bold(),
      new Code(),
      new Strike(),
      new Underline(),
      ...
    ]