### PR TITLE
add text search and replace

### DIFF
--- a/examples/Components/Routes/Search/index.vue
+++ b/examples/Components/Routes/Search/index.vue
@@ -175,7 +175,9 @@ export default {
           new HardBreak(),
           new Heading({ levels: [1, 2, 3] }),
           new HorizontalRule(),
-          new Search(),
+          new Search({
+            disableRegex: false,
+          }),
           new ListItem(),
           new OrderedList(),
           new TodoItem(),

--- a/examples/Components/Routes/Search/index.vue
+++ b/examples/Components/Routes/Search/index.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="editor">
+    <editor-menu-bar :editor="editor" v-slot="{ commands, isActive }">
+      <div class="menubar">
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.bold() }"
+          @click="commands.bold"
+        >
+          <icon name="bold" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.italic() }"
+          @click="commands.italic"
+        >
+          <icon name="italic" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.strike() }"
+          @click="commands.strike"
+        >
+          <icon name="strike" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.underline() }"
+          @click="commands.underline"
+        >
+          <icon name="underline" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.code() }"
+          @click="commands.code"
+        >
+          <icon name="code" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.paragraph() }"
+          @click="commands.paragraph"
+        >
+          <icon name="paragraph" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.heading({ level: 1 }) }"
+          @click="commands.heading({ level: 1 })"
+        >
+          H1
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.bullet_list() }"
+          @click="commands.bullet_list"
+        >
+          <icon name="ul" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.ordered_list() }"
+          @click="commands.ordered_list"
+        >
+          <icon name="ol" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.blockquote() }"
+          @click="commands.blockquote"
+        >
+          <icon name="quote" />
+        </button>
+
+        <button
+          class="menubar__button"
+          :class="{ 'is-active': isActive.code_block() }"
+          @click="commands.code_block"
+        >
+          <icon name="code" />
+        </button>
+
+        <button
+          class="menubar__button"
+          @click="commands.undo"
+        >
+          <icon name="undo" />
+        </button>
+
+        <button
+          class="menubar__button"
+          @click="commands.redo"
+        >
+          <icon name="redo" />
+        </button>
+
+        <button
+            class="menubar__button"
+            @click="toggleSearch"
+        >
+          Search
+          <div
+              class="search-modal"
+              @click.stop
+              v-if="editor.extensions.options.search.searching"
+          >
+            <input
+                ref="search"
+                @keydown.enter.prevent="editor.commands.find(searchTerm)"
+                placeholder="Search..."
+                type="text"
+                v-model="searchTerm"
+            >
+            <button @click="editor.commands.find(searchTerm)">Find</button>
+          </div>
+        </button>
+
+      </div>
+    </editor-menu-bar>
+
+    <editor-content class="editor__content" :editor="editor" />
+  </div>
+</template>
+
+<script>
+import Icon from 'Components/Icon'
+import { Editor, EditorContent, EditorMenuBar } from 'tiptap'
+import {
+  Blockquote,
+  CodeBlock,
+  HardBreak,
+  Heading,
+  HorizontalRule,
+  OrderedList,
+  BulletList,
+  ListItem,
+  TodoItem,
+  TodoList,
+  Bold,
+  Code,
+  Italic,
+  Link,
+  Strike,
+  Underline,
+  History,
+  Search,
+} from 'tiptap-extensions'
+
+export default {
+  components: {
+    EditorContent,
+    EditorMenuBar,
+    Icon,
+  },
+  methods: {
+    toggleSearch() {
+      this.editor.commands.toggleSearch()
+      this.$nextTick(() => {
+        if (this.$refs.search) {
+          this.$refs.search.focus()
+        }
+      })
+    },
+  },
+  data() {
+    return {
+      searching: false,
+      searchTerm: null,
+      editor: new Editor({
+        extensions: [
+          new Blockquote(),
+          new BulletList(),
+          new CodeBlock(),
+          new HardBreak(),
+          new Heading({ levels: [1, 2, 3] }),
+          new HorizontalRule(),
+          new Search(),
+          new ListItem(),
+          new OrderedList(),
+          new TodoItem(),
+          new TodoList(),
+          new Link(),
+          new Bold(),
+          new Code(),
+          new Italic(),
+          new Strike(),
+          new Underline(),
+          new History(),
+        ],
+        onUpdate: ({ getJSON }) => {
+          this.json = getJSON()
+        },
+        content: `
+          <h2>
+            Hi there,
+          </h2>
+          <p>
+            this is a very <em>basic</em> example of tiptap.
+          </p>
+          <pre><code>body { display: none; }</code></pre>
+          <ul>
+            <li>
+              A regular list
+            </li>
+            <li>
+              With regular items
+            </li>
+          </ul>
+          <blockquote>
+            It's amazing 👏
+            <br />
+            – mom
+          </blockquote>
+        `,
+      }),
+    }
+  },
+  beforeDestroy() {
+    this.editor.destroy()
+  },
+}
+</script>
+
+<style>
+  .menubar__button {
+    position: relative;
+  }
+
+  .search-modal {
+    position: absolute;
+    top: 100%;
+    display: flex;
+    background: #fff;
+    padding: .5em;
+    box-shadow: 0 2px 4px #0003;
+    border-radius: 2px;
+    left: 0;
+    margin-top: 0.25em;
+    border: solid 2px;
+  }
+
+  .find {
+    background: rgba(255, 213, 0, 0.5);
+  }
+</style>

--- a/examples/Components/Routes/Search/index.vue
+++ b/examples/Components/Routes/Search/index.vue
@@ -121,9 +121,16 @@
                 placeholder="Search..."
                 type="text"
                 v-model="searchTerm"
-            >
+            ><input
+              @keydown.enter.prevent="editor.commands.replace(replaceWith)"
+              placeholder="Replace..."
+              type="text"
+              v-model="replaceWith"
+          >
             <button @click="editor.commands.find(searchTerm)">Find</button>
             <button @click="editor.commands.clearSearch()">Clear</button>
+            <button @click="editor.commands.replace(replaceWith)">Replace</button>
+            <button @click="editor.commands.replaceAll(replaceWith)">Replace All</button>
           </div>
         </span>
 
@@ -168,6 +175,7 @@ export default {
     return {
       searching: false,
       searchTerm: null,
+      replaceWith: null,
       editor: new Editor({
         extensions: [
           new Blockquote(),

--- a/examples/Components/Routes/Search/index.vue
+++ b/examples/Components/Routes/Search/index.vue
@@ -123,6 +123,7 @@
                 v-model="searchTerm"
             >
             <button @click="editor.commands.find(searchTerm)">Find</button>
+            <button @click="editor.commands.clearSearch()">Clear</button>
           </div>
         </span>
 

--- a/examples/Components/Routes/Search/index.vue
+++ b/examples/Components/Routes/Search/index.vue
@@ -105,7 +105,7 @@
           <icon name="redo" />
         </button>
 
-        <button
+        <span
             class="menubar__button"
             @click="editor.commands.toggleSearch"
         >
@@ -124,7 +124,7 @@
             >
             <button @click="editor.commands.find(searchTerm)">Find</button>
           </div>
-        </button>
+        </span>
 
       </div>
     </editor-menu-bar>

--- a/examples/Components/Routes/Search/index.vue
+++ b/examples/Components/Routes/Search/index.vue
@@ -107,7 +107,7 @@
 
         <button
             class="menubar__button"
-            @click="toggleSearch"
+            @click="editor.commands.toggleSearch"
         >
           Search
           <div
@@ -163,16 +163,6 @@ export default {
     EditorMenuBar,
     Icon,
   },
-  methods: {
-    toggleSearch() {
-      this.editor.commands.toggleSearch()
-      this.$nextTick(() => {
-        if (this.$refs.search) {
-          this.$refs.search.focus()
-        }
-      })
-    },
-  },
   data() {
     return {
       searching: false,
@@ -200,6 +190,13 @@ export default {
         ],
         onUpdate: ({ getJSON }) => {
           this.json = getJSON()
+        },
+        onToggleSearch: searching => {
+          this.$nextTick(() => {
+            if (searching) {
+              this.$refs.search.focus()
+            }
+          })
         },
         content: `
           <h2>

--- a/examples/Components/Subnavigation/index.vue
+++ b/examples/Components/Subnavigation/index.vue
@@ -24,6 +24,9 @@
     <router-link class="subnavigation__link" to="/tables">
       Tables
     </router-link>
+    <router-link class="subnavigation__link" to="/search">
+      Search
+    </router-link>
     <router-link class="subnavigation__link" to="/suggestions">
       Suggestions
     </router-link>

--- a/examples/assets/sass/menubar.scss
+++ b/examples/assets/sass/menubar.scss
@@ -33,4 +33,8 @@
       background-color: rgba($color-black, 0.1);
     }
   }
+
+  span#{&}__button {
+    font-size: 13.3333px;
+  }
 }

--- a/examples/main.js
+++ b/examples/main.js
@@ -69,6 +69,13 @@ const routes = [
     },
   },
   {
+    path: '/search',
+    component: () => import('Components/Routes/Search'),
+    meta: {
+      githubUrl: 'https://github.com/scrumpy/tiptap/tree/master/examples/Components/Routes/Search',
+    },
+  },
+  {
     path: '/suggestions',
     component: () => import('Components/Routes/Suggestions'),
     meta: {

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -25,6 +25,7 @@ export default class Search extends Extension {
       searching: false,
       caseSensitive: false,
       disableRegex: true,
+      alwaysSearch: false,
     }
   }
 
@@ -121,7 +122,7 @@ export default class Search extends Extension {
         state: {
           init() { return DecorationSet.empty },
           apply: (tr, old) => {
-            if (this.options.searching) {
+            if (this.options.searching || (tr.docChanged && this.options.alwaysSearch)) {
               return this.createDeco(tr.doc)
             }
             if (tr.docChanged) {

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -115,26 +115,29 @@ export default class Search extends Extension {
     }
   }
 
-  rebaseNextResult(replace, index) {
+  rebaseNextResult(replace, index, lastOffset = 0) {
     const nextIndex = index + 1
-    if (!this.results[nextIndex]) return
+    if (!this.results[nextIndex]) return null
 
-    const nextStep = this.results[nextIndex]
-    const { from, to } = nextStep
-    const offset = (to - from - replace.length) * nextIndex
+    const { from: currentFrom, to: currentTo } = this.results[index]
+    const offset = (currentTo - currentFrom - replace.length) + lastOffset
 
+    const { from, to } = this.results[nextIndex]
     this.results[nextIndex] = {
       to: to - offset,
       from: from - offset,
     }
+
+    return offset
   }
 
   replaceAll(replace) {
     return ({ tr }, dispatch) => {
+      let offset
       this.results.forEach(({ from, to }, index) => {
         tr.insertText(replace, from, to)
 
-        this.rebaseNextResult(replace, index)
+        offset = this.rebaseNextResult(replace, index, offset)
       })
 
       dispatch(tr)

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -94,7 +94,8 @@ export default class Search extends Extension {
     mergedTextNodes.forEach(({ text, pos }) => {
       const search = this.findRegExp
       let m
-      while (m = search.exec(text)) {
+      // eslint-disable-next-line no-cond-assign
+      while ((m = search.exec(text))) {
         if (m[0] === '') {
           break
         }

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -24,6 +24,7 @@ export default class Search extends Extension {
       findClass: 'find',
       searching: false,
       caseSensitive: false,
+      disableRegex: true,
     }
   }
 
@@ -103,7 +104,7 @@ export default class Search extends Extension {
   find(searchTerm) {
     return ({ tr }, dispatch) => {
       this.options.searching = true
-      this.searchTerm = searchTerm
+      this.searchTerm = (this.options.disableRegex) ? searchTerm.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') : searchTerm
 
       dispatch(tr)
     }

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -95,9 +95,15 @@ export default class Search extends Extension {
       new Plugin({
         state: {
           init: (_, { doc }) => this.createDeco(doc),
-          apply: (tr, old) => (
-            (tr.docChanged || this.options.searching) ? this.createDeco(tr.doc) : old
-          ),
+          apply: (tr, old) => {
+            if (this.options.searching) {
+              return this.createDeco(tr.doc)
+            }
+            if (tr.docChanged) {
+              return old.map(tr.mapping, tr.doc)
+            }
+            return old
+          },
         },
         props: {
           decorations(state) { return this.getState(state) },

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -1,0 +1,109 @@
+import { Extension, Plugin } from 'tiptap'
+import { Decoration, DecorationSet } from 'prosemirror-view'
+
+export default class Search extends Extension {
+
+  constructor(options = {}) {
+    super(options)
+
+    this.results = []
+    this.searchTerm = null
+  }
+
+  get name() {
+    return 'search'
+  }
+
+  get defaultOptions() {
+    return {
+      autoSelectNext: true,
+      findClass: 'find',
+      searching: false,
+      caseSensitive: false,
+    }
+  }
+
+  toggleSearch() {
+    return () => {
+      this.options.searching = !this.options.searching
+      return true
+    }
+  }
+
+  keys() {
+    return {
+      'Mod-f': this.toggleSearch(),
+    }
+  }
+
+  commands() {
+    return {
+      find: attrs => this.find(attrs),
+      toggleSearch: () => this.toggleSearch(),
+    }
+  }
+
+  get findRegExp() {
+    return RegExp(this.searchTerm, !this.options.caseSensitive ? 'gi' : 'g')
+  }
+
+  get decorations() {
+    return this.results.map(deco => (
+        Decoration.inline(deco.from, deco.to, { class: this.options.findClass })
+    ))
+  }
+
+  _search(doc) {
+    this.results = []
+
+    if (!this.searchTerm) {
+      return
+    }
+
+    const search = this.findRegExp
+
+    doc.descendants((node, pos) => {
+      if (node.isText) {
+        let m
+        while (m = search.exec(node.text)) {
+          this.results.push({
+            from: pos + m.index,
+            to: pos + m.index + m[0].length,
+          })
+        }
+      }
+    })
+  }
+
+  find(searchTerm) {
+    return ({ doc, tr }, dispatch) => {
+      this.options.searching = true
+      this.searchTerm = searchTerm
+
+      this._search(doc)
+
+      dispatch(tr)
+    }
+  }
+
+  createDeco(doc) {
+    return this.decorations ? DecorationSet.create(doc, this.decorations) : []
+  }
+
+  get plugins() {
+    return [
+      new Plugin({
+        state: {
+          init: (_, { doc }) => this.createDeco(doc),
+          apply: (tr, old) => (
+            (tr.docChanged || this.options.searching) ? this.createDeco(tr.doc) : old
+          ),
+        },
+        props: {
+          decorations(state) { return this.getState(state) },
+        },
+      }),
+    ]
+  }
+
+}

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -14,6 +14,10 @@ export default class Search extends Extension {
     return 'search'
   }
 
+  init() {
+    this.editor.events.push('toggleSearch')
+  }
+
   get defaultOptions() {
     return {
       autoSelectNext: true,
@@ -26,6 +30,7 @@ export default class Search extends Extension {
   toggleSearch() {
     return () => {
       this.options.searching = !this.options.searching
+      this.editor.emit('toggleSearch', this.options.searching)
       return true
     }
   }

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -99,17 +99,16 @@ export default class Search extends Extension {
   }
 
   find(searchTerm) {
-    return ({ doc, tr }, dispatch) => {
+    return ({ tr }, dispatch) => {
       this.options.searching = true
       this.searchTerm = searchTerm
-
-      this._search(doc)
 
       dispatch(tr)
     }
   }
 
   createDeco(doc) {
+    this._search(doc)
     return this.decorations ? DecorationSet.create(doc, this.decorations) : []
   }
 
@@ -117,7 +116,7 @@ export default class Search extends Extension {
     return [
       new Plugin({
         state: {
-          init: (_, { doc }) => this.createDeco(doc),
+          init() { return DecorationSet.empty },
           apply: (tr, old) => {
             if (this.options.searching) {
               return this.createDeco(tr.doc)

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -53,7 +53,7 @@ export default class Search extends Extension {
   }
 
   get findRegExp() {
-    return RegExp(this.searchTerm, !this.options.caseSensitive ? 'gi' : 'g')
+    return RegExp(this.searchTerm, !this.options.caseSensitive ? 'gui' : 'gu')
   }
 
   get decorations() {

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -46,6 +46,7 @@ export default class Search extends Extension {
   commands() {
     return {
       find: attrs => this.find(attrs),
+      clearSearch: () => this.clear(),
       toggleSearch: () => this.toggleSearch(),
     }
   }
@@ -106,6 +107,14 @@ export default class Search extends Extension {
     return ({ tr }, dispatch) => {
       this.options.searching = true
       this.searchTerm = (this.options.disableRegex) ? searchTerm.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') : searchTerm
+
+      dispatch(tr)
+    }
+  }
+
+  clear() {
+    return ({ tr }, dispatch) => {
+      this.searchTerm = null
 
       dispatch(tr)
     }

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -55,6 +55,8 @@ export default class Search extends Extension {
 
   _search(doc) {
     this.results = []
+    const mergedTextNodes = []
+    let index = 0
 
     if (!this.searchTerm) {
       return
@@ -64,13 +66,29 @@ export default class Search extends Extension {
 
     doc.descendants((node, pos) => {
       if (node.isText) {
-        let m
-        while (m = search.exec(node.text)) {
-          this.results.push({
-            from: pos + m.index,
-            to: pos + m.index + m[0].length,
-          })
+        if (mergedTextNodes[index]) {
+          mergedTextNodes[index] = {
+            text: mergedTextNodes[index].text + node.text,
+            pos: mergedTextNodes[index].pos,
+          }
+        } else {
+          mergedTextNodes[index] = {
+            text: node.text,
+            pos,
+          }
         }
+      } else {
+        index += 1
+      }
+    })
+
+    mergedTextNodes.forEach(({ text, pos }) => {
+      let m
+      while (m = search.exec(text)) {
+        this.results.push({
+          from: pos + m.index,
+          to: pos + m.index + m[0].length,
+        })
       }
     })
   }

--- a/packages/tiptap-extensions/src/extensions/Search.js
+++ b/packages/tiptap-extensions/src/extensions/Search.js
@@ -67,8 +67,6 @@ export default class Search extends Extension {
       return
     }
 
-    const search = this.findRegExp
-
     doc.descendants((node, pos) => {
       if (node.isText) {
         if (mergedTextNodes[index]) {
@@ -88,8 +86,12 @@ export default class Search extends Extension {
     })
 
     mergedTextNodes.forEach(({ text, pos }) => {
+      const search = this.findRegExp
       let m
       while (m = search.exec(text)) {
+        if (m[0] === '') {
+          break
+        }
         this.results.push({
           from: pos + m.index,
           to: pos + m.index + m[0].length,

--- a/packages/tiptap-extensions/src/index.js
+++ b/packages/tiptap-extensions/src/index.js
@@ -26,6 +26,7 @@ export { default as Underline } from './marks/Underline'
 export { default as Collaboration } from './extensions/Collaboration'
 export { default as History } from './extensions/History'
 export { default as Placeholder } from './extensions/Placeholder'
+export { default as Search } from './extensions/Search'
 
 export { default as Suggestions } from './plugins/Suggestions'
 export { default as Highlight } from './plugins/Highlight'

--- a/packages/tiptap/src/Editor.js
+++ b/packages/tiptap/src/Editor.js
@@ -82,7 +82,7 @@ export default class Editor extends Emitter {
     }
 
     this.events.forEach(name => {
-      this.on(name, this.options[camelCase(`on ${name}`)])
+        this.on(name, this.options[camelCase(`on ${name}`)] || (() => {}))
     })
 
     this.emit('init', {


### PR DESCRIPTION
Working on a search and replace plugin:
- [x] search
- [x] clear search
- [x] replace (only next found match will be replaced)
- [x] replace all

Known Bugs:
- [x] ~search hightlight doesn't get updated on text changes~ (fixed in 753fc7632418dd7066062488ef045cf7dc4902c6)
- [x] ~search across marks is not possible (@philippkuehn do you know how that can be achived?)~ (fixed in 331ba1c36b738ece3eb3b03e31747afdb3c71a59)
- [x] ~currently on pressing spacebar the click handler of search button is triggerd (why? 😅)~ (fixed in 036d853378ba8323532d7ed9df5749301f5b4365)
- [x] ~Some searchterms break the editor. (`.*` crashes, `.` breaks emojis) (maybe disable regex at all 🤔)~ (fixed by 0476d355995bacd96a1d2c72a39145148feb5b6c)
- [x] ~Emojis are still broken with some RegExps ...~ (fixed by  (3246b84229ea8492b8f596f216410543d57dbede))



This will close #224