### PR TITLE
prevent resizehandles in IE 11 on todo_items

### DIFF
--- a/packages/tiptap-extensions/src/nodes/TodoItem.js
+++ b/packages/tiptap-extensions/src/nodes/TodoItem.js
@@ -24,7 +24,7 @@ export default class TodoItem extends Node {
         },
       },
       template: `
-        <li :data-type="node.type.name" :data-done="node.attrs.done.toString()">
+        <li :data-type="node.type.name" :data-done="node.attrs.done.toString()" contenteditable="false">
           <span class="todo-checkbox" contenteditable="false" @click="onChange"></span>
           <div class="todo-content" ref="content" :contenteditable="view.editable.toString()"></div>
         </li>

--- a/packages/tiptap-extensions/src/nodes/TodoList.js
+++ b/packages/tiptap-extensions/src/nodes/TodoList.js
@@ -11,7 +11,7 @@ export default class TodoList extends Node {
     return {
       group: 'block',
       content: 'todo_item+',
-      toDOM: () => ['ul', { 'data-type': this.name }, 0],
+      toDOM: () => ['ul', { 'data-type': this.name, contenteditable: false }, 0],
       parseDOM: [{
         priority: 51,
         tag: `[data-type="${this.name}"]`,


### PR DESCRIPTION
Accoridng to this [answer](https://stackoverflow.com/a/26101367/6370595) from stackoverflow it helps to apply `contenteditable="false"` to the parent element. 

So this is what this PR does.

fixes #340 