### PR TITLE
Handle composition state in MenuBubble

### DIFF
--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -85,7 +85,7 @@ class Menu {
 
   update(view, lastState) {
     const { state } = view
-    
+
     if (view.composing) {
       return
     }

--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -85,6 +85,10 @@ class Menu {
 
   update(view, lastState) {
     const { state } = view
+    
+    if (view.composing) {
+      return
+    }
 
     // Don't do anything if the document/selection didn't change
     if (lastState && lastState.doc.eq(state.doc) && lastState.selection.eq(state.selection)) {


### PR DESCRIPTION
Thank you for great software tiptap!!
Menu Bubble show menu when I select text but I think showing is not needed when I'm selecting Japanese character and I think using browser composing function user agree with me.

bad
![bad](https://user-images.githubusercontent.com/8707452/60691536-633e6180-9f0b-11e9-80c7-dc50a9ea4fc4.gif)

good
![good](https://user-images.githubusercontent.com/8707452/60691543-6a656f80-9f0b-11e9-9aa8-5f5430e6439e.gif)

I add small composing handler.
Please check them when you have time.
Thank you.