### PR TITLE
Switch check from !isMac to isWindows for specificity.

### DIFF
--- a/packages/tiptap-extensions/src/extensions/History.js
+++ b/packages/tiptap-extensions/src/extensions/History.js
@@ -15,13 +15,13 @@ export default class History extends Extension {
   }
 
   keys() {
-    const isMac = typeof navigator !== 'undefined' ? /Mac/.test(navigator.platform) : false
+    const isWindows = typeof navigator !== 'undefined' ? /Win/.test(navigator.platform) : false
     const keymap = {
       'Mod-z': undo,
       'Shift-Mod-z': redo,
     }
 
-    if (!isMac) {
+    if (isWindows) {
       keymap['Mod-y'] = redo
     }
 


### PR DESCRIPTION
Only Windows uses Mod+y, this avoids adding the shortcut to other operating systems (such as Linux or iOS).

This adds better support for spoofed user-agents when testing mobile sites on desktop devices.

You could also add `|| /Pocket/.test(navigator.platform)` but it really is optional