### PR TITLE
improve regexp that parses the heading #

### DIFF
--- a/packages/tiptap-extensions/src/nodes/Heading.js
+++ b/packages/tiptap-extensions/src/nodes/Heading.js
@@ -48,7 +48,7 @@ export default class Heading extends Node {
 
   inputRules({ type }) {
     return this.options.levels.map(level => textblockTypeInputRule(
-      new RegExp(`^(#{1,${level}})\\s$`),
+      new RegExp(`^(#{${level}})\\s$`),
       type,
       () => ({ level }),
     ))


### PR DESCRIPTION
for a given heading level, the number of # is fixed.

There is no need for a regexp to capture #'s with sizes from 1 to "level", capturing only #'s with a size that is exactly "level" should work and presumably faster.