### PR TITLE
Allow Extensions to redefine the behaviour of setSelection

### DIFF
--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -41,6 +41,10 @@ export default class ComponentView {
       updateAttrs: attrs => this.updateAttrs(attrs),
     }
 
+    if (typeof this.extension.setSelection === 'function') {
+      this.setSelection = this.extension.setSelection
+    }
+
     this.vm = new Component({
       parent: this.parent,
       propsData: props,


### PR DESCRIPTION
I've been implementing CodeMirror within ProseMirror per the [ProseMirror example](https://prosemirror.net/examples/codemirror/). However, the example redefines the behaviour of setSelection on the NodeView so that it focuses the CodeMirror instance. This PR allows Extensions to define a new setSelection function.