### PR TITLE
MenuBubbles below the selection

### DIFF
--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -66,6 +66,7 @@ class Menu {
     this.isActive = false
     this.left = 0
     this.bottom = 0
+    this.top = 0
 
     // the mousedown event is fired before blur so we can prevent it
     this.options.element.addEventListener('mousedown', this.handleClick)
@@ -129,6 +130,7 @@ class Menu {
     this.left = Math.round(this.options.keepInBounds
         ? Math.min(box.width - (el.width / 2), Math.max(left, el.width / 2)) : left)
     this.bottom = Math.round(box.bottom - start.top)
+    this.top = Math.round(end.bottom - box.top)
     this.isActive = true
 
     this.sendUpdate()
@@ -139,6 +141,7 @@ class Menu {
       isActive: this.isActive,
       left: this.left,
       bottom: this.bottom,
+      top: this.top,
     })
   }
 


### PR DESCRIPTION
This adds a top property to the menu so that you can have the MenuBubble render below the selection instead of above it. Set `top: ${menu.top}` in the MenuBubble styles to render below.