### PR TITLE
add support for empty selection to removeMark and updateMark

### DIFF
--- a/packages/tiptap-commands/src/commands/removeMark.js
+++ b/packages/tiptap-commands/src/commands/removeMark.js
@@ -1,6 +1,17 @@
 export default function (type) {
   return (state, dispatch) => {
-    const { from, to } = state.selection
+    const { empty, $cursor } = state.selection
+    let { from, to } = state.selection
+
+    if (empty && $cursor) {
+      const { parent, pos, textOffset } = $cursor
+      const parentOffset = pos - textOffset
+      const { node: { nodeSize } } = parent.childAfter(parentOffset)
+
+      from = parentOffset
+      to = from + nodeSize
+    }
+
     return dispatch(state.tr.removeMark(from, to, type))
   }
 }

--- a/packages/tiptap-commands/src/commands/updateMark.js
+++ b/packages/tiptap-commands/src/commands/updateMark.js
@@ -1,6 +1,17 @@
 export default function (type, attrs) {
   return (state, dispatch) => {
-    const { from, to } = state.selection
+    const { empty, $cursor } = state.selection
+    let { from, to } = state.selection
+
+    if (empty && $cursor) {
+      const { parent, pos, textOffset } = $cursor
+      const parentOffset = pos - textOffset
+      const { node: { nodeSize } } = parent.childAfter(parentOffset)
+
+      from = parentOffset
+      to = from + nodeSize
+    }
+
     return dispatch(state.tr.addMark(from, to, type.create(attrs)))
   }
 }


### PR DESCRIPTION
This will allow us to change marks under cursor without to select it first.
fixes #449

Only downside as far as I can tell is that without selection and running a command like `commands.link()` will link the currently nearest node.