### PR TITLE
fix(menu-bubble-hide): only send hide update, target not child of editor

### DIFF
--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -143,7 +143,7 @@ class Menu {
   }
 
   hide(event) {
-    if (event && event.relatedTarget) {
+    if (event && event.relatedTarget && this.options.element.parentNode.contains(event.relatedTarget)) {
       return
     }
 


### PR DESCRIPTION
closes #473

possible solution for menu bubble not hiding when you focus away to a control element (input, etc.)

check the parent node of the menu bubble.
usually a container that contains both the menu and the editor-content
if the relatedTarget (where we are focusing to) is a child of the parent, we don't hide
if it is not we can hide the bubble menu

