### PR TITLE
Fix leaf nodes not selectable

### DIFF
--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -116,6 +116,8 @@ export default class ComponentView {
   // prevent a full re-render of the vue component on update
   // we'll handle prop updates in `update()`
   ignoreMutation(mutation) {
+
+    // allow leaf nodes to be selected
     if (mutation.type === "selection") {
       return false;
     }

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -116,10 +116,9 @@ export default class ComponentView {
   // prevent a full re-render of the vue component on update
   // we'll handle prop updates in `update()`
   ignoreMutation(mutation) {
-
     // allow leaf nodes to be selected
-    if (mutation.type === "selection") {
-      return false;
+    if (mutation.type === 'selection') {
+      return false
     }
 
     if (!this.contentDOM) {

--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -116,6 +116,10 @@ export default class ComponentView {
   // prevent a full re-render of the vue component on update
   // we'll handle prop updates in `update()`
   ignoreMutation(mutation) {
+    if (mutation.type === "selection") {
+      return false;
+    }
+
     if (!this.contentDOM) {
       return true
     }


### PR DESCRIPTION
Since prosemirror-view 1.9.13 the dom event handler will call a node view's ignoreMutation() to determine if the node selection should be updated. This causes custom leaf nodes (with no contentDOM) to become unselectable. This patch will allow selection events to go through without restrictions.
