### PR TITLE
Add support for historical paths

### DIFF
--- a/packages/tiptap-extensions/src/extensions/History.js
+++ b/packages/tiptap-extensions/src/extensions/History.js
@@ -1,5 +1,7 @@
 import { Extension } from 'tiptap'
-import { history, undo, redo, undoDepth, redoDepth } from 'prosemirror-history'
+import {
+ history, undo, redo, undoDepth, redoDepth,
+} from 'prosemirror-history'
 
 export default class History extends Extension {
 

--- a/packages/tiptap-extensions/src/extensions/History.js
+++ b/packages/tiptap-extensions/src/extensions/History.js
@@ -1,5 +1,5 @@
 import { Extension } from 'tiptap'
-import { history, undo, redo } from 'prosemirror-history'
+import { history, undo, redo, undoDepth, redoDepth } from 'prosemirror-history'
 
 export default class History extends Extension {
 
@@ -37,6 +37,8 @@ export default class History extends Extension {
     return {
       undo: () => undo,
       redo: () => redo,
+      undoDepth: () => undoDepth,
+      redoDepth: () => redoDepth,
     }
   }
 


### PR DESCRIPTION
I realized that tiptap does not have support for historical paths, and Prosemirror has implemented this feature.Used to control the state of the button.
![image](https://user-images.githubusercontent.com/22025605/68000556-88fe2c00-fc9b-11e9-9183-02d51b1002d3.png)



