### PR TITLE
Fix error on hide event

### DIFF
--- a/packages/tiptap/src/Plugins/MenuBubble.js
+++ b/packages/tiptap/src/Plugins/MenuBubble.js
@@ -155,6 +155,7 @@ class Menu {
   hide(event) {
     if (event
       && event.relatedTarget
+      && this.options.element.parentNode
       && this.options.element.parentNode.contains(event.relatedTarget)
     ) {
       return


### PR DESCRIPTION
Sometimes the hide event throws an error since the element of the option does not have a parent node. I added a check if the parent node is not null to the hide event. 

```javascript
tiptap.esm.js?cd42:1849 Uncaught TypeError: Cannot read property 'contains' of null
    at Menu.hide (tiptap.esm.js?cd42:1849)
    at Editor.eval (tiptap.esm.js?cd42:1778)
    at eval (tiptap.esm.js?cd42:461)
    at Array.forEach (<anonymous>)
    at Editor.emit (tiptap.esm.js?cd42:460)
    at Plugin.blur (tiptap.esm.js?cd42:1184)
    at eval (index.es.js?576a:3113)
    at EditorView.someProp (index.es.js?576a:4567)
    at runCustomHandler (index.es.js?576a:3111)
    at HTMLDivElement.view.dom.addEventListener.view.eventHandlers.<computed> (index.es.js?576a:3076)
```