### PR TITLE
Allow extensions to define update behavior.

### DIFF
--- a/packages/tiptap/src/Utils/ComponentView.js
+++ b/packages/tiptap/src/Utils/ComponentView.js
@@ -44,6 +44,9 @@ export default class ComponentView {
     if (typeof this.extension.setSelection === 'function') {
       this.setSelection = this.extension.setSelection
     }
+    if (typeof this.extension.update === 'function') {
+      this.update = this.extension.update
+    }
 
     this.vm = new Component({
       parent: this.parent,


### PR DESCRIPTION
This PR allows extensions to define their own [update](https://prosemirror.net/docs/ref/#view.NodeView.update) behavior. Similar to the pr from #419, in that it's needed to implement a CodeMirror Node in TipTap based off [the ProseMirror example](https://prosemirror.net/examples/codemirror/). From the ProseMirror page,

> When an update comes in from the editor, for example because of an undo action, we kind of have to do the inverse of what valueChanged did—check for text changes, and if present, propagate them from the outer to the inner editor.

An example of usage:

```js
import CodeMirror from "codemirror"
export default class CodeBlock extends Node {
   ...
  update(node) {
    if (node.type != this.vm.node.type) return false
    this.vm.node = node
    let change = this.vm.computeChange(this.vm.cm.getValue(), node.textContent)
    if (change) {
      this.vm.updating = true
      this.vm.cm.replaceRange(change.text, this.vm.cm.posFromIndex(change.from),
      this.vm.cm.posFromIndex(change.to))
      this.vm.updating = false
    }
    return true
  }
}
```