### PR TITLE
Added node components props to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,10 @@ export default class IframeNode extends Node {
       // `updateAttrs` is a function to update attributes defined in `schema`
       // `view` is the ProseMirror view instance
       // `options` is an array of your extension options
-      // `selected`
+      // `selected` is a boolean which is true when selected
+      // `editor` is a reference to the TipTap editor instance
+      // `getPos` is a function to retrieve the start position of the node
+      // `decorations` is an array of decorations around the node
       props: ['node', 'updateAttrs', 'view'],
       computed: {
         src: {


### PR DESCRIPTION
The readme was missing a few props that are passed to node components. It took me a while to figure out that they were there, so I thought I might as well make it easier for someone else.