### PR TITLE
Apply decorations in HighlightPlugin if change in named nodes.

### DIFF
--- a/packages/tiptap-extensions/src/plugins/Highlight.js
+++ b/packages/tiptap-extensions/src/plugins/Highlight.js
@@ -64,15 +64,15 @@ export default function HighlightPlugin({ name }) {
       init: (_, { doc }) => getDecorations({ doc, name }),
       apply: (transaction, decorationSet, oldState, state) => {
         // TODO: find way to cache decorations
-        // see: https://discuss.prosemirror.net/t/how-to-update-multiple-inline-decorations-on-node-change/1493
-
-        const nodeName = state.selection.$head.parent.type.name
-        const previousNodeName = oldState.selection.$head.parent.type.name
-
-        if (transaction.docChanged && [nodeName, previousNodeName].includes(name)) {
+        // https://discuss.prosemirror.net/t/how-to-update-multiple-inline-decorations-on-node-change/1493
+        const oldNodeName = oldState.selection.$head.parent.type.name
+        const newNodeName = newState.selection.$head.parent.type.name
+        const oldNodes = findBlockNodes(oldState.doc).filter(item => item.node.type.name === name)
+        const newNodes = findBlockNodes(newState.doc).filter(item => item.node.type.name === name)
+        // Apply decorations if selection includes named node, or transaction changes named node.
+        if (transaction.docChanged && ([oldNodeName, newNodeName].includes(name) || newNodes.length != oldNodes.length)) {
           return getDecorations({ doc: transaction.doc, name })
         }
-
         return decorationSet.map(transaction.mapping, transaction.doc)
       },
     },

--- a/packages/tiptap-extensions/src/plugins/Highlight.js
+++ b/packages/tiptap-extensions/src/plugins/Highlight.js
@@ -62,15 +62,18 @@ export default function HighlightPlugin({ name }) {
     name: new PluginKey('highlight'),
     state: {
       init: (_, { doc }) => getDecorations({ doc, name }),
-      apply: (transaction, decorationSet, oldState, state) => {
+      apply: (transaction, decorationSet, oldState, newState) => {
         // TODO: find way to cache decorations
         // https://discuss.prosemirror.net/t/how-to-update-multiple-inline-decorations-on-node-change/1493
         const oldNodeName = oldState.selection.$head.parent.type.name
         const newNodeName = newState.selection.$head.parent.type.name
-        const oldNodes = findBlockNodes(oldState.doc).filter(item => item.node.type.name === name)
-        const newNodes = findBlockNodes(newState.doc).filter(item => item.node.type.name === name)
+        const oldNodes = findBlockNodes(oldState.doc)
+          .filter(item => item.node.type.name === name)
+        const newNodes = findBlockNodes(newState.doc)
+          .filter(item => item.node.type.name === name)
         // Apply decorations if selection includes named node, or transaction changes named node.
-        if (transaction.docChanged && ([oldNodeName, newNodeName].includes(name) || newNodes.length != oldNodes.length)) {
+        if (transaction.docChanged && ([oldNodeName, newNodeName].includes(name)
+          || newNodes.length !== oldNodes.length)) {
           return getDecorations({ doc: transaction.doc, name })
         }
         return decorationSet.map(transaction.mapping, transaction.doc)


### PR DESCRIPTION
This PR applies [decorations](https://prosemirror.net/docs/ref/#view.Decorations) in the [Highlight Plugin](https://github.com/scrumpy/tiptap/blob/master/packages/tiptap-extensions/src/plugins/Highlight.js) if there is a change in the number of nodes. This is useful for cases when new nodes are programmatically created such that the current selection is not within the new nodes. 

An example of of this is with collaborative editing: another user may create a new CodeBlock node that's updated into the main user's editor. Without this PR, the new CodeBlock is created but is not highlighted.