### PR TITLE
fix(markpasterule): parent is undefined for mark

### DIFF
--- a/packages/tiptap-commands/src/commands/markPasteRule.js
+++ b/packages/tiptap-commands/src/commands/markPasteRule.js
@@ -16,7 +16,7 @@ export default function (regexp, type, getAttrs) {
 
         // eslint-disable-next-line
         while (!isLink && (match = regexp.exec(text)) !== null) {
-          if (parent.type.allowsMarkType(type) && match[1]) {
+          if (parent && parent.type.allowsMarkType(type) && match[1]) {
             const start = match.index
             const end = start + match[0].length
             const textStart = start + match[0].indexOf(match[1])


### PR DESCRIPTION
check parent exists

currently seeing the following error a lot on paste
`Cannot read property 'type' of undefined`

function arguments only contain the fragment and no parent
```js
[{
  currentTarget: div._1hgD7 > div._2HMtf._1da_S > div.ProseMirror.ProseMirror - focused,
  isTrusted: [object ClipboardEvent],
  target: div.ProseMirror.ProseMirror - focused > div._2v_ft.is - editor - empty > br,
  type: paste
}]
```
