### PR TITLE
fixed issue of user object format coming from search() of fuse.js

### DIFF
--- a/examples/Components/Routes/Suggestions/index.vue
+++ b/examples/Components/Routes/Suggestions/index.vue
@@ -134,7 +134,12 @@ export default {
                 keys: ['name'],
               })
 
-              return fuse.search(query)
+              const queriedUsers = fuse.search(query);
+              const matchedUsers = queriedUsers.reduce((acc, queriedUser) => {
+                return acc.concat(queriedUser.item);
+              }, []);
+
+              return matchedUsers;
             },
           }),
           new Code(),


### PR DESCRIPTION
fix:
When someone types something after '@' like @P then nothing shows due user object format returning from search() of fuse.js as below. And now after this fix, it is showing correctly.
@philippkuehn - please have a look at it.

fix of the issue created - https://github.com/scrumpy/tiptap/issues/693

![image](https://user-images.githubusercontent.com/30753467/81511111-89efd480-9334-11ea-9ed7-17853cf325f5.png)


 
