### PR TITLE
Allow attributes for wrappers

### DIFF
--- a/packages/tiptap-commands/src/commands/toggleWrap.js
+++ b/packages/tiptap-commands/src/commands/toggleWrap.js
@@ -1,14 +1,14 @@
 import { wrapIn, lift } from 'prosemirror-commands'
 import { nodeIsActive } from 'tiptap-utils'
 
-export default function (type) {
+export default function (type, attrs = {}) {
   return (state, dispatch, view) => {
-    const isActive = nodeIsActive(state, type)
+    const isActive = nodeIsActive(state, type, attrs)
 
     if (isActive) {
       return lift(state, dispatch)
     }
 
-    return wrapIn(type)(state, dispatch, view)
+    return wrapIn(type, attrs)(state, dispatch, view)
   }
 }


### PR DESCRIPTION
### Fix
When creating a custom node of type wrapper you cannot pass attributes as you could with a classic block type.
Simply fixed by adding a second parameter to the _toggleWrap_ function for attributes, and by passing them to _isNodeActive_ and _wrapIn_ methods.

Then we can use attributes the same way we do with _toggleBlockType_

```javascript
  commands ({ type, schema }) {
    return attrs => toggleWrap(type, attrs)
  }
```

By the way, thanks for the amazing work !!